### PR TITLE
Avoid deep type inference in dynamic table update

### DIFF
--- a/app/api/tables/[table]/route.ts
+++ b/app/api/tables/[table]/route.ts
@@ -58,9 +58,9 @@ export async function PUT(
     }
 
     const client = getClient();
-    const { data, error } = await client
-      .from(params.table)
-      .update(values)
+    const tableQuery = client.from(params.table as string) as any;
+    const { data, error } = await tableQuery
+      .update(values as Record<string, unknown>)
       .eq(primaryKey, primaryValue)
       .select()
       .single();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,13 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.cjs",
+    "**/*.mjs",
+    ".next/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- add the generated `.next/types/**/*.ts` directory to the TypeScript include list so Next.js types are discovered
- relax the Supabase dynamic table update typing to avoid "type instantiation is excessively deep" build failures

## Testing
- `npm run build` *(fails: Next.js CLI not available because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e21edde2a8832b92bd20035caa4661